### PR TITLE
BaSP-TG-22: Time-sheets 'Get by id' and 'Update' tests

### DIFF
--- a/src/controllers/time-sheets.js
+++ b/src/controllers/time-sheets.js
@@ -75,13 +75,19 @@ export const editTimeSheet = async (req, res) => {
       req.body,
       { new: true },
     );
-    return res.status(200).json({
-      message: `Time sheet with id ${id} edited`,
-      data: result,
-      error: false,
-    });
+    return !result
+      ? res.status(404).json({
+        message: `The time-sheet with the id ${id} was not found`,
+        data: undefined,
+        error: true,
+      })
+      : res.status(200).json({
+        message: `Time sheet with id ${id} edited`,
+        data: result,
+        error: false,
+      });
   } catch (err) {
-    return res.status(404).json({
+    return res.status(400).json({
       message: err.toString(),
       data: undefined,
       error: true,

--- a/src/test/time-sheets.test.js
+++ b/src/test/time-sheets.test.js
@@ -21,6 +21,9 @@ const mockedTimeSheet = {
 
 const shorterId = '635325a5c39a0040ecf7a86';
 const largerId = '635325a5c39a0040ecf7a8601';
+const notFindedId = '635325a5c39a0040ecf7a861';
+// eslint-disable-next-line no-underscore-dangle
+const timesheetId = timeSheetSeed[0]._id;
 
 describe('TESTS endpoints /time-sheets', () => {
   beforeAll(async () => {
@@ -45,6 +48,30 @@ describe('TESTS endpoints /time-sheets', () => {
       expect(response.body.error).toBeFalsy();
       expect(response.body.data).toStrictEqual([]);
       expect(response.body.data.length).not.toBeGreaterThan(0);
+    });
+  });
+
+  describe('GET by ID', () => {
+    test('status should be 200', async () => {
+      const response = await request(app).get(`/time-sheets/${timesheetId}`).send();
+      expect(response.status).toBe(200);
+      expect(response.body.error).toBeFalsy();
+      expect(response.body.data).toMatchObject({
+        _id: timesheetId,
+      });
+    });
+
+    test('should not get an employee by ID which is not in DB', async () => {
+      const response = await request(app).get(`/time-sheets/${notFindedId}`).send();
+      expect(response.status).toBe(404);
+      expect(response.body.error).toBeTruthy();
+    });
+
+    test('should not get an employee by an invalid ID', async () => {
+      const response = await request(app).get(`/time-sheets/${shorterId}`).send();
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
     });
   });
 

--- a/src/test/time-sheets.test.js
+++ b/src/test/time-sheets.test.js
@@ -71,7 +71,7 @@ describe('TESTS endpoints /time-sheets', () => {
   });
 
   describe('GET by ID /time-sheets', () => {
-    test('status should be 200', async () => {
+    test('status should be 200 and get an object from the timesheet', async () => {
       const response = await request(app).get(`/time-sheets/${timesheetId}`).send();
       expect(response.status).toBe(200);
       expect(response.body.error).toBeFalsy();
@@ -80,13 +80,13 @@ describe('TESTS endpoints /time-sheets', () => {
       });
     });
 
-    test('should not get an employee by ID which is not in DB', async () => {
+    test('status should be 404 not get an employee when the id is not in the DB', async () => {
       const response = await request(app).get(`/time-sheets/${notFoundId}`).send();
       expect(response.status).toBe(404);
       expect(response.body.error).toBeTruthy();
     });
 
-    test('should not get an employee by an invalid ID', async () => {
+    test('status should be 400 and not get an employee when the id is invalid', async () => {
       const response = await request(app).get(`/time-sheets/${shorterId}`).send();
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();

--- a/src/test/time-sheets.test.js
+++ b/src/test/time-sheets.test.js
@@ -19,9 +19,28 @@ const mockedTimeSheet = {
   project: mongoose.Types.ObjectId('63532304206881f4ae0b709b'),
 };
 
+const mockedWrongTimeSheet = {
+  invalid: 'This field is not valid',
+  description: 'Example for testing with jest in timesheet',
+  date: '2022-03-22T03:00:00.000Z',
+  hours: 15,
+  task: mongoose.Types.ObjectId('635325a5c39a0040ecf7a860'),
+  employees: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
+  project: mongoose.Types.ObjectId('63532304206881f4ae0b709b'),
+};
+
+const mockedIncompleteTimeSheet = {
+  invalid: 'This field is not valid',
+  description: 'Example for testing with jest in timesheet',
+  hours: 15,
+  task: mongoose.Types.ObjectId('635325a5c39a0040ecf7a860'),
+  employees: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
+  project: mongoose.Types.ObjectId('63532304206881f4ae0b709b'),
+};
+
 const shorterId = '635325a5c39a0040ecf7a86';
 const largerId = '635325a5c39a0040ecf7a8601';
-const notFindedId = '635325a5c39a0040ecf7a861';
+const notFoundId = '635325a5c39a0040ecf7a861';
 // eslint-disable-next-line no-underscore-dangle
 const timesheetId = timeSheetSeed[0]._id;
 
@@ -51,7 +70,7 @@ describe('TESTS endpoints /time-sheets', () => {
     });
   });
 
-  describe('GET by ID', () => {
+  describe('GET by ID /time-sheets', () => {
     test('status should be 200', async () => {
       const response = await request(app).get(`/time-sheets/${timesheetId}`).send();
       expect(response.status).toBe(200);
@@ -62,7 +81,7 @@ describe('TESTS endpoints /time-sheets', () => {
     });
 
     test('should not get an employee by ID which is not in DB', async () => {
-      const response = await request(app).get(`/time-sheets/${notFindedId}`).send();
+      const response = await request(app).get(`/time-sheets/${notFoundId}`).send();
       expect(response.status).toBe(404);
       expect(response.body.error).toBeTruthy();
     });
@@ -191,6 +210,170 @@ describe('TESTS endpoints /time-sheets', () => {
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
       expect(response.body.data).toBe(undefined);
+    });
+  });
+
+  describe('PUT /time-sheets', () => {
+    test('status should be 200 and must return an edited time-sheet', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        description: 'New description',
+      });
+      expect(response.status).toBe(200);
+      expect(response.body.error).toBeFalsy();
+      expect(response.body.data).toMatchObject({
+        _id: timesheetId,
+      });
+      expect(response.body.data.description).toBe('New description');
+    });
+
+    test('status should be 400 and not edit anything when the body is invalid', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedWrongTimeSheet,
+        description: 'New description',
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 and not edit anything when the body is empty', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send();
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when a required field is not in the body', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedIncompleteTimeSheet,
+        description: 'New description',
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the description is shorter than 3', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        description: 'Ne',
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the description is larger than 300', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        description: 'Should not work, phrase repeated till 313 character.'
+        + 'Should not work, phrase repeated till 313 character.Should not work, phrase repeted till 301 character.'
+        + 'Should not work, phrase repeated till 313 character.Should not work, phrase repeted till 301 character.'
+        + 'Should not work, phrase repeated till 313 character.',
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the date is not ISO formated', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        date: '22-03-2022',
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the hours are negative', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        hours: -15,
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the hours are not a number', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        hours: 'String',
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the task id is shorter than 24', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        task: shorterId,
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the task id is longer than 24', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        task: largerId,
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the employees id is shorter than 24', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        employees: shorterId,
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the employees id is longer than 24', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        employees: largerId,
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the project id is shorter than 24', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        project: shorterId,
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 400 when the project id is longer than 24', async () => {
+      const response = await request(app).put(`/time-sheets/${timesheetId}`).send({
+        ...mockedTimeSheet,
+        project: largerId,
+      });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBeTruthy();
+      expect(response.body.data).not.toBeDefined();
+    });
+
+    test('status should be 404 and not edit anything when the id is not found', async () => {
+      const response = await request(app).put(`/time-sheets/${notFoundId}`).send({
+        ...mockedTimeSheet,
+        description: 'New description',
+      });
+      expect(response.status).toBe(404);
+      expect(response.body.error).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
In this PR I added the tests for the 'Get by id' and 'Update' methods from time-sheets and I fixed the responses from the controller