### PR TITLE
BaSP-TG-Fix: Fix to timesheet validation and model

### DIFF
--- a/src/controllers/time-sheets.js
+++ b/src/controllers/time-sheets.js
@@ -50,7 +50,7 @@ export const createTimeSheet = async (req, res) => {
       description: req.body.description,
       date: req.body.date,
       hours: req.body.hours,
-      tasks: req.body.tasks,
+      task: req.body.task,
       employee: req.body.employee,
       project: req.body.project,
     });

--- a/src/test/time-sheets.test.js
+++ b/src/test/time-sheets.test.js
@@ -21,7 +21,7 @@ const mockedTimeSheet = {
   date: '2022-03-22T03:00:00.000Z',
   hours: 15,
   task: mongoose.Types.ObjectId('635325a5c39a0040ecf7a860'),
-  employees: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
+  employee: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
   project: mongoose.Types.ObjectId('63532304206881f4ae0b709b'),
 };
 
@@ -31,7 +31,7 @@ const mockedWrongTimeSheet = {
   date: '2022-03-22T03:00:00.000Z',
   hours: 15,
   task: mongoose.Types.ObjectId('635325a5c39a0040ecf7a860'),
-  employees: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
+  employee: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
   project: mongoose.Types.ObjectId('63532304206881f4ae0b709b'),
 };
 
@@ -40,7 +40,7 @@ const mockedIncompleteTimeSheet = {
   description: 'Example for testing with jest in timesheet',
   hours: 15,
   task: mongoose.Types.ObjectId('635325a5c39a0040ecf7a860'),
-  employees: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
+  employee: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
   project: mongoose.Types.ObjectId('63532304206881f4ae0b709b'),
 };
 

--- a/src/validations/time-sheets.js
+++ b/src/validations/time-sheets.js
@@ -6,7 +6,7 @@ const validateTimeSheetBody = (req, res, next) => {
     date: Joi.date().iso().required(),
     hours: Joi.number().positive().required(),
     task: Joi.string().length(24).required(),
-    employees: Joi.string().length(24).required(),
+    employee: Joi.string().length(24).required(),
     project: Joi.string().length(24).required(),
   });
 


### PR DESCRIPTION
- Fixed controllers/time-sheet.js file at line 53 ( "tasks" replaced with "task") so it can display task at the Data Base.
- Fixed validations/time-sheet.js file at line 9 ("employees" replaced with "employee") so it can display employee at the Data Base.
- time-sheets test modified according the fixes listed above.

