### PR TITLE
BaSP-TG-48: Add new validations to date and hours on Timesheets

### DIFF
--- a/src/test/time-sheets.test.js
+++ b/src/test/time-sheets.test.js
@@ -19,7 +19,7 @@ const notFoundId = '635325a5c39a0040ecf7a861';
 const mockedTimeSheet = {
   description: 'Example for testing with jest in timesheet',
   date: '2022-03-22T03:00:00.000Z',
-  hours: 15,
+  hours: 12,
   task: mongoose.Types.ObjectId('635325a5c39a0040ecf7a860'),
   employee: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
   project: mongoose.Types.ObjectId('63532304206881f4ae0b709b'),
@@ -29,7 +29,7 @@ const mockedWrongTimeSheet = {
   invalid: 'This field is not valid',
   description: 'Example for testing with jest in timesheet',
   date: '2022-03-22T03:00:00.000Z',
-  hours: 15,
+  hours: 10,
   task: mongoose.Types.ObjectId('635325a5c39a0040ecf7a860'),
   employee: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
   project: mongoose.Types.ObjectId('63532304206881f4ae0b709b'),
@@ -38,7 +38,7 @@ const mockedWrongTimeSheet = {
 const mockedIncompleteTimeSheet = {
   invalid: 'This field is not valid',
   description: 'Example for testing with jest in timesheet',
-  hours: 15,
+  hours: 2,
   task: mongoose.Types.ObjectId('635325a5c39a0040ecf7a860'),
   employee: mongoose.Types.ObjectId('635325adc90228d7485c0e1f'),
   project: mongoose.Types.ObjectId('63532304206881f4ae0b709b'),

--- a/src/validations/time-sheets.js
+++ b/src/validations/time-sheets.js
@@ -6,26 +6,30 @@ const validateTimeSheetBody = (req, res, next) => {
       .required()
       .messages({
         'string.base': 'Description must be a string',
-        'string.empty': 'Description is not allowed to be empty',
+        'string.empty': 'Description field is required',
         'string.trim': 'Description is not allowed to be empty',
         'string.min': 'Description must have at least 3 characters',
         'string.max': 'Description can not bet longer than 300 characters',
         'string.required': 'Description is required',
         'any.required': 'Description is required',
       }),
-    date: Joi.date().iso().required().messages({
-      'any.required': 'Date is required',
-      'date.base': 'Insert a valid date',
-      'data.empty': 'Date is not allowed to be empty',
-      'date.format': 'Date must follow the pattern yyyy-mm-dd',
-      'date.required': 'Date is required',
-    }),
-    hours: Joi.number().min(1).positive()
+    date: Joi.date().iso().less('now').required()
+      .messages({
+        'any.required': 'Date is required',
+        'date.base': 'Insert a valid date',
+        'data.empty': 'Date is not allowed to be empty',
+        'date.format': 'Date must follow the pattern DD-MM-AAAA',
+        'date.less': 'Date can not be greater than today',
+        'date.required': 'Date is required',
+      }),
+    hours: Joi.number().min(1).max(12).positive()
       .required()
       .messages({
         'any.required': 'Hours are required',
         'number.empty': 'Hours are not allowed to be empty',
         'number.base': 'Hours must contain only numbers',
+        'number.min': 'The minimum amount of hours must be 1 or higher',
+        'number.max': 'The maximum amout of hours that can be registered are 12',
         'number.positive': 'The minimum amount of hours must be 1 or higher.',
         'number.required': 'Hours are required',
       }),

--- a/src/validations/time-sheets.js
+++ b/src/validations/time-sheets.js
@@ -13,15 +13,15 @@ const validateTimeSheetBody = (req, res, next) => {
         'string.required': 'Description is required',
         'any.required': 'Description is required',
       }),
-    date: Joi.date().iso().required()
-      .messages({
-        'any.required': 'Date is required',
-        'date.base': 'Insert a valid date',
-        'data.empty': 'Date is not allowed to be empty',
-        'date.format': 'Date must follow the pattern yyyy-mm-dd',
-        'date.required': 'Date is required',
-      }),
-    hours: Joi.number().positive().required()
+    date: Joi.date().iso().required().messages({
+      'any.required': 'Date is required',
+      'date.base': 'Insert a valid date',
+      'data.empty': 'Date is not allowed to be empty',
+      'date.format': 'Date must follow the pattern yyyy-mm-dd',
+      'date.required': 'Date is required',
+    }),
+    hours: Joi.number().min(1).positive()
+      .required()
       .messages({
         'any.required': 'Hours are required',
         'number.empty': 'Hours are not allowed to be empty',
@@ -29,24 +29,23 @@ const validateTimeSheetBody = (req, res, next) => {
         'number.positive': 'The minimum amount of hours must be 1 or higher.',
         'number.required': 'Hours are required',
       }),
-    task: Joi.string().length(24).required()
-      .messages({
-        'any.required': 'Tasks are required',
-        'string.required': 'Please insert a task',
-      }),
-    employee: Joi.string().length(24).required()
-      .messages({
-        'any.required': 'Employee is required',
-        'string.required': 'Please insert a employee',
-      }),
-    project: Joi.string().length(24).required()
-      .messages({
-        'any.required': 'Project is required',
-        'string.required': 'Please insert a project',
-      }),
+    task: Joi.string().length(24).required().messages({
+      'any.required': 'Tasks are required',
+      'string.required': 'Please insert a task',
+    }),
+    employee: Joi.string().length(24).required().messages({
+      'any.required': 'Employee is required',
+      'string.required': 'Please insert a employee',
+    }),
+    project: Joi.string().length(24).required().messages({
+      'any.required': 'Project is required',
+      'string.required': 'Please insert a project',
+    }),
   });
 
-  const validation = timeSheetValidation.validate(req.body, { abortEarly: false });
+  const validation = timeSheetValidation.validate(req.body, {
+    abortEarly: false,
+  });
 
   if (validation.error) {
     return res.status(400).json({

--- a/src/validations/time-sheets.js
+++ b/src/validations/time-sheets.js
@@ -4,7 +4,8 @@ const validateTimeSheetBody = (req, res, next) => {
   const timeSheetValidation = Joi.object({
     description: Joi.string().min(3).max(300).required(),
     date: Joi.date().iso().required(),
-    hours: Joi.number().positive().required(),
+    hours: Joi.number().positive().integer().positive()
+      .required(),
     task: Joi.string().length(24).required(),
     employee: Joi.string().length(24).required(),
     project: Joi.string().length(24).required(),


### PR DESCRIPTION
- Description accepts special characters.
- Now date can notregister future dates, only until today.
- Hours must be 1 or higher and equal to 12 or lower.