### PR TITLE
BaSP-TG-49: Correction of inputs cant be left blank

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.0",
         "joi": "^17.6.3",
@@ -3477,6 +3478,18 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -6680,6 +6693,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -10871,6 +10892,15 @@
         }
       }
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -13263,6 +13293,11 @@
       "requires": {
         "path-key": "^3.0.0"
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
       "version": "1.12.0",

--- a/src/validations/admins.js
+++ b/src/validations/admins.js
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 export const validateCreation = (req, res, next) => {
-  const letterSpacesRegEx = /^[a-zA-Z\s]*$/;
+  const letterSpacesRegEx = /[A-Za-z]{3}([A-Za-z]+ ?)*/;
   const adminValidation = Joi.object({
     name: Joi.string().min(3).max(50).regex(letterSpacesRegEx)
       .required(),

--- a/src/validations/employees.js
+++ b/src/validations/employees.js
@@ -1,9 +1,12 @@
 import Joi from 'joi';
 
 const validateEmployeesBody = (req, res, next) => {
+  const letterSpacesRegEx = /[A-Za-z]{3}([A-Za-z]+ ?)*/;
   const employeeValidation = Joi.object({
-    name: Joi.string().min(3).max(50).required(),
-    lastName: Joi.string().min(3).max(50).required(),
+    name: Joi.string().min(3).max(50).regex(letterSpacesRegEx)
+      .required(),
+    lastName: Joi.string().min(3).max(50).regex(letterSpacesRegEx)
+      .required(),
     phone: Joi.string().length(10).regex(/^[0-9]+$/).required(),
     email: Joi.string().email().required(),
     password: Joi.string().regex(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}$/).required(),

--- a/src/validations/super-admins.js
+++ b/src/validations/super-admins.js
@@ -1,9 +1,12 @@
 import Joi from 'joi';
 
 const validateSuperAdminsBody = (req, res, next) => {
+  const letterSpacesRegEx = /[A-Za-z]{3}([A-Za-z]+ ?)*/;
   const superAdminValidation = Joi.object({
-    name: Joi.string().min(3).max(50).required(),
-    last_name: Joi.string().min(3).max(50).required(),
+    name: Joi.string().min(3).max(50).regex(letterSpacesRegEx)
+      .required(),
+    last_name: Joi.string().min(3).max(50).regex(letterSpacesRegEx)
+      .required(),
     email: Joi.string().email(),
     password: Joi.string().pattern(/^[a-zA-Z0-9]{3,30}$/),
   });

--- a/src/validations/tasks.js
+++ b/src/validations/tasks.js
@@ -1,8 +1,10 @@
 import Joi from 'joi';
 
 export const validateTaskBody = (req, res, next) => {
+  const letterSpacesRegEx = /[A-Za-z]{3}([A-Za-z]+ ?)*/;
   const taskValidation = Joi.object({
-    description: Joi.string().min(3).max(300).required(),
+    description: Joi.string().min(3).max(300).regex(letterSpacesRegEx)
+      .required(),
   });
 
   const validation = taskValidation.validate(req.body);


### PR DESCRIPTION
The changes are made in Admins, SuperAdmins, Timesheets and task. 

- The error that occurred is that it allowed the entities to be created by taking blank spaces in the inputs, for example when creating the admin name you could put three spaces and it would take it as correct.

- Fixed by creating a regex that fixes that