### PR TITLE
BaSP-TG-108-110: Fix Regex and update Error messages

### DIFF
--- a/src/test/admins.test.js
+++ b/src/test/admins.test.js
@@ -45,28 +45,28 @@ describe('Admins - Unit tests', () => {
       const res = await request(app).post('/admins').send({ ...mockedAdmin, name: 'R' });
       expect(res.status).toBe(400);
       expect(res.body.error).toBeTruthy();
-      expect(res.body.message).toEqual('Error: Name must have a minimum of 3 letters');
+      expect(res.body.message).toEqual('Name must have a minimum of 3 letters');
     });
 
     test('Should return status code 400 and not create an admin when we are sending an invalid last name in the request body.', async () => {
       const res = await request(app).post('/admins').send({ ...mockedAdmin, lastName: 'R' });
       expect(res.status).toBe(400);
       expect(res.body.error).toBeTruthy();
-      expect(res.body.message).toEqual('Error: Last Name must have a minimum of 3 letters');
+      expect(res.body.message).toEqual('Last Name must have a minimum of 3 letters');
     });
 
     test('Should return status code 400 and not create an admin when we are sending an invalid email in the request body.', async () => {
       const res = await request(app).post('/admins').send({ ...mockedAdmin, email: 'R' });
       expect(res.status).toBe(400);
       expect(res.body.error).toBeTruthy();
-      expect(res.body.message).toEqual('Error: Insert a valid email');
+      expect(res.body.message).toEqual('Insert a valid email');
     });
 
     test('Should return status code 400 and not create an admin when we are sending an invalid password in the request body.', async () => {
       const res = await request(app).post('/admins').send({ ...mockedAdmin, password: 'R' });
       expect(res.status).toBe(400);
       expect(res.body.error).toBeTruthy();
-      expect(res.body.message).toEqual('Error: Password must contain at least 8 characters, "one" capital letter, "one" lower case and "one" number at least');
+      expect(res.body.message).toEqual('Password must contain at least 8 characters, "one" capital letter, "one" lower case and "one" number at least');
     });
   });
 

--- a/src/test/employees.test.js
+++ b/src/test/employees.test.js
@@ -60,7 +60,7 @@ describe('Employee - Tests', () => {
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
       expect(response.body.data).toBeUndefined();
-      expect(response.body.message).toEqual('Error: Name is required');
+      expect(response.body.message).toEqual('Name is required');
     });
 
     test('should return an error with status 400 when we are sending an invalid name in the request body', async () => {
@@ -70,7 +70,7 @@ describe('Employee - Tests', () => {
       });
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: Name must have a minimum of 3 letters');
+      expect(response.body.message).toEqual('Name must have a minimum of 3 letters');
     });
 
     test('should return an error with status 400 when we are sending an invalid last name in the request body', async () => {
@@ -80,7 +80,7 @@ describe('Employee - Tests', () => {
       });
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: Last Name must have a minimum of 3 letters');
+      expect(response.body.message).toEqual('Last Name must have a minimum of 3 letters');
     });
 
     test('should return an error with status 400 when we are sending an phone in the request body', async () => {
@@ -90,7 +90,7 @@ describe('Employee - Tests', () => {
       });
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "phone" length must be 10 characters long');
+      expect(response.body.message).toEqual('Phone number must be 10 characters long');
     });
 
     test('should return an error with status 400 when we are sending an email in the request body', async () => {
@@ -100,7 +100,7 @@ describe('Employee - Tests', () => {
       });
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: Insert a valid email');
+      expect(response.body.message).toEqual('Insert a valid email');
     });
 
     test('should return an error with status 400 when we are sending an password in the request body', async () => {
@@ -110,7 +110,7 @@ describe('Employee - Tests', () => {
       });
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: Password must contain at least 8 characters, "one" capital letter, "one" lower case and "one" number.');
+      expect(response.body.message).toEqual('Password must contain at least 8 characters, "one" capital letter, "one" lower case and "one" number.');
     });
   });
 
@@ -131,7 +131,7 @@ describe('Employee - Tests', () => {
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
       expect(response.body.data).toBeUndefined();
-      expect(response.body.message).toEqual('Error: Name is required');
+      expect(response.body.message).toEqual('Name is required');
     });
   });
 

--- a/src/test/projects.test.js
+++ b/src/test/projects.test.js
@@ -64,42 +64,42 @@ describe('Projects - Test', () => {
       const response = await request(app).post('/projects').send({ mockedProject, name: 'a' });
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "name" length must be at least 3 characters long');
+      expect(response.body.message).toEqual('"name" length must be at least 3 characters long');
     });
 
     test('should not create a project when the user sends an invalid project description', async () => {
       const response = await request(app).post('/projects').send(({ mockedProject, description: 'a' }));
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "name" is required');
+      expect(response.body.message).toEqual('"name" is required');
     });
 
     test('should not create a project when the user sends an invalid project endDate', async () => {
       const response = await request(app).post('/projects').send(({ mockedProject, endDate: 'a' }));
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "name" is required');
+      expect(response.body.message).toEqual('"name" is required');
     });
 
     test('should not create a project when the user sends an invalid project clientName', async () => {
       const response = await request(app).post('/projects').send(({ mockedProject, clientName: 'a' }));
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "name" is required');
+      expect(response.body.message).toEqual('"name" is required');
     });
 
     test('should not create a project when the user sends an invalid project startDate', async () => {
       const response = await request(app).post('/projects').send(({ mockedProject, startDate: 'a' }));
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "name" is required');
+      expect(response.body.message).toEqual('"name" is required');
     });
 
     test('should not create a project when the user sends an invalid project employee', async () => {
       const response = await request(app).post('/projects').send(({ mockedProject, employee: 'a' }));
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "name" is required');
+      expect(response.body.message).toEqual('"name" is required');
     });
   });
 

--- a/src/test/super-admins.test.js
+++ b/src/test/super-admins.test.js
@@ -65,7 +65,7 @@ describe('Super-admins - Unit tests', () => {
       expect(response.body.data).toBeUndefined();
       expect(response.body.error).toBeTruthy();
       expect(response.body.message).toBeDefined();
-      expect(response.body.message).toEqual('Error: "name" is required');
+      expect(response.body.message).toEqual('"name" is required');
     });
 
     test('should return an error with status 400 when we are sending an invalid name in the request body', async () => {
@@ -75,7 +75,7 @@ describe('Super-admins - Unit tests', () => {
       });
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "name" length must be at least 3 characters long');
+      expect(response.body.message).toEqual('"name" length must be at least 3 characters long');
     });
 
     test('should return an error with status 400 when we are sending an invalid last name in the request body', async () => {
@@ -85,7 +85,7 @@ describe('Super-admins - Unit tests', () => {
       });
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "lastName" is not allowed');
+      expect(response.body.message).toEqual('"lastName" is not allowed');
     });
 
     test('should return an error with status 400 when we are sending an invalid e-mail in the request bodythe super admin should not be created, wrong e-mail', async () => {
@@ -95,7 +95,7 @@ describe('Super-admins - Unit tests', () => {
       });
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "email" must be a valid email');
+      expect(response.body.message).toEqual('"email" must be a valid email');
     });
 
     test('should return an error with status 400 when we are sending an invalid password in the request body', async () => {
@@ -105,7 +105,7 @@ describe('Super-admins - Unit tests', () => {
       });
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
-      expect(response.body.message).toEqual('Error: "password" with value "2" fails to match the required pattern: /^[a-zA-Z0-9]{3,30}$/');
+      expect(response.body.message).toEqual('"password" with value "2" fails to match the required pattern: /^[a-zA-Z0-9]{3,30}$/');
     });
   });
 
@@ -125,7 +125,7 @@ describe('Super-admins - Unit tests', () => {
       expect(response.status).toBe(400);
       expect(response.body.error).toBeTruthy();
       expect(response.body.data).toBeUndefined();
-      expect(response.body.message).toEqual('Error: "name" is required');
+      expect(response.body.message).toEqual('"name" is required');
     });
 
     test('should not edit a super admin when the user sends an invalid id', async () => {

--- a/src/validations/admins.js
+++ b/src/validations/admins.js
@@ -1,13 +1,12 @@
 import Joi from 'joi';
 
 export const validateCreation = (req, res, next) => {
-  const letterSpacesRegEx = /[A-Za-z]{3}([A-Za-z]+ ?)*/;
   const adminValidation = Joi.object({
     name: Joi.string()
       .min(3)
       .trim()
       .max(30)
-      .regex(letterSpacesRegEx)
+      .regex(/^([^0-9]*)$/i)
       .required()
       .messages({
         'any.required': 'Name is required',
@@ -15,10 +14,10 @@ export const validateCreation = (req, res, next) => {
         'string.empty': 'Name is not allowed to be empty',
         'string.min': 'Name must have a minimum of 3 letters',
         'string.max': 'Name can contain more than 30 letters',
-        'string.pattern.base': 'Name must have a minimum of 3 letters',
+        'string.pattern.base': 'Name can only contain letters',
         'string.required': 'Name field is required',
       }),
-    lastName: Joi.string().min(3).max(30).regex(letterSpacesRegEx)
+    lastName: Joi.string().min(3).max(30).regex(/^([^0-9]*)$/i)
       .required()
       .messages({
         'any.required': 'Last Name is required',
@@ -26,7 +25,7 @@ export const validateCreation = (req, res, next) => {
         'string.base': 'Last Name must be a string',
         'string.min': 'Last Name must have a minimum of 3 letters',
         'string.max': 'Last Name can contain more than 30 letters',
-        'string.pattern.base': 'Last Name must have a minimum of 3 letters',
+        'string.pattern.base': 'Name can only contain letters',
         'string.required': 'Last Name field is required',
       }),
     email: Joi.string().email().required().messages({
@@ -39,6 +38,7 @@ export const validateCreation = (req, res, next) => {
       .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$/)
       .required().messages({
         'any.required': 'a password is required',
+        'string.empty': 'Password field is not allowed to be empty',
         'string.pattern.base': 'Password must contain at least 8 characters, "one" capital letter, "one" lower case and "one" number at least',
         'string.required': 'Password field is required',
       }),
@@ -46,7 +46,7 @@ export const validateCreation = (req, res, next) => {
   const validation = adminValidation.validate(req.body);
   if (validation.error) {
     return res.status(400).json({
-      message: `Error: ${validation.error.details[0].message}`,
+      message: validation.error.details[0].message,
       data: undefined,
       error: true,
     });
@@ -85,7 +85,7 @@ export const validateEdit = (req, res, next) => {
         'string.empty': 'Name is not allowed to be empty',
         'string.min': 'Name must have a minimum of 3 letters',
         'string.max': 'Name can contain more than 30 letters',
-        'string.pattern.base': 'Name must have a minimum of 3 letters',
+        'string.pattern.base': 'Name can only contain letters',
         'string.required': 'Name field is required',
       }),
     lastName: Joi.string().min(3).max(30).regex(letterSpacesRegEx)
@@ -95,7 +95,7 @@ export const validateEdit = (req, res, next) => {
         'string.base': 'Last Name must be a string',
         'string.min': 'Last Name must have a minimum of 3 letters',
         'string.max': 'Last Name can contain more than 30 letters',
-        'string.pattern.base': 'Last Name must have a minimum of 3 letters',
+        'string.pattern.base': 'Name can only contain letters',
         'string.required': 'Last Name field is required',
       }),
     email: Joi.string().email().messages({
@@ -108,6 +108,7 @@ export const validateEdit = (req, res, next) => {
       /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d]{8,}$/,
     ).messages({
       'any.required': 'a password is required',
+      'string.empty': 'Password field is not allowed to be empty',
       'string.pattern.base': 'Password must contain at least 8 characters, "one" capital letter, "one" lower case and "one" number at least',
       'string.required': 'email field is required',
     }),
@@ -115,7 +116,7 @@ export const validateEdit = (req, res, next) => {
   const validation = adminValidation.validate(req.body);
   if (validation.error) {
     return res.status(400).json({
-      message: `Error: ${validation.error.details[0].message}`,
+      message: validation.error.details[0].message,
       data: undefined,
       error: true,
     });

--- a/src/validations/employees.js
+++ b/src/validations/employees.js
@@ -1,10 +1,9 @@
 import Joi from 'joi';
 
 const validateEmployeesBody = (req, res, next) => {
-  const letterSpacesRegEx = /[A-Za-z]{3}([A-Za-z]+ ?)*/;
   const employeeValidation = Joi.object({
     name: Joi.string().min(3).trim().max(30)
-      .regex(letterSpacesRegEx)
+      .regex(/^([^0-9]*)$/i)
       .required()
       .messages({
         'any.required': 'Name is required',
@@ -12,11 +11,11 @@ const validateEmployeesBody = (req, res, next) => {
         'string.empty': 'Name is not allowed to be empty',
         'string.min': 'Name must have a minimum of 3 letters',
         'string.max': 'Name can contain more than 30 letters',
-        'string.pattern.base': 'Name must have a minimum of 3 letters',
+        'string.pattern.base': 'Name can only contain letters',
         'string.required': 'Name field is required',
       }),
     lastName: Joi.string().min(3).trim().max(30)
-      .regex(letterSpacesRegEx)
+      .regex(/^([^0-9]*)$/i)
       .required()
       .messages({
         'any.required': 'Last Name is required',
@@ -24,7 +23,7 @@ const validateEmployeesBody = (req, res, next) => {
         'string.base': 'Last Name must be a string',
         'string.min': 'Last Name must have a minimum of 3 letters',
         'string.max': 'Last Name can contain more than 30 letters',
-        'string.pattern.base': 'Last Name must have a minimum of 3 letters',
+        'string.pattern.base': 'Name can only contain letters',
         'string.required': 'Last Name field is required',
       }),
     phone: Joi.string().length(10).regex(/^[0-9]+$/).required()
@@ -32,6 +31,7 @@ const validateEmployeesBody = (req, res, next) => {
         'any.required': 'Phone number is required',
         'string.empty': 'Phone number is not allowed to be empty',
         'string.base': 'Phone number can only contain numbers',
+        'string.length': 'Phone number must be 10 characters long',
         'string.pattern.base': 'Phone number can only contain numbers',
         'string.required': 'Phone number field is required',
       }),
@@ -53,7 +53,7 @@ const validateEmployeesBody = (req, res, next) => {
   const validation = employeeValidation.validate(req.body);
   if (validation.error) {
     return res.status(400).json({
-      message: `Error: ${validation.error.details[0].message}`,
+      message: validation.error.details[0].message,
       data: undefined,
       error: true,
     });

--- a/src/validations/projects.js
+++ b/src/validations/projects.js
@@ -33,7 +33,7 @@ export const validateProjectBody = (req, res, next) => {
 
   if (validation.error) {
     return res.status(400).json({
-      message: `Error: ${validation.error.details[0].message}`,
+      message: validation.error.details[0].message,
       data: undefined,
       error: true,
     });
@@ -51,7 +51,7 @@ export const validateEmployeeBody = (req, res, next) => {
 
   if (validation.error) {
     return res.status(400).json({
-      message: `Error: ${validation.error.details[0].message}`,
+      message: validation.error.details[0].message,
       data: undefined,
       error: true,
     });

--- a/src/validations/super-admins.js
+++ b/src/validations/super-admins.js
@@ -1,11 +1,10 @@
 import Joi from 'joi';
 
 const validateSuperAdminsBody = (req, res, next) => {
-  const letterSpacesRegEx = /[A-Za-z]{3}([A-Za-z]+ ?)*/;
   const superAdminValidation = Joi.object({
-    name: Joi.string().min(3).max(50).regex(letterSpacesRegEx)
+    name: Joi.string().min(3).max(50).regex(/^([^0-9]*)$/i)
       .required(),
-    last_name: Joi.string().min(3).max(50).regex(letterSpacesRegEx)
+    last_name: Joi.string().min(3).max(50).regex(/^([^0-9]*)$/i)
       .required(),
     email: Joi.string().email(),
     password: Joi.string().pattern(/^[a-zA-Z0-9]{3,30}$/),
@@ -13,7 +12,7 @@ const validateSuperAdminsBody = (req, res, next) => {
   const validation = superAdminValidation.validate(req.body);
   if (validation.error) {
     return res.status(400).json({
-      message: `Error: ${validation.error.details[0].message}`,
+      message: validation.error.details[0].message,
       data: undefined,
       error: true,
     });

--- a/src/validations/tasks.js
+++ b/src/validations/tasks.js
@@ -11,7 +11,7 @@ export const validateTaskBody = (req, res, next) => {
 
   if (validation.error) {
     return res.status(400).json({
-      message: `Error: ${validation.error.details[0].message}`,
+      message: validation.error.details[0].message,
       data: undefined,
       error: true,
     });

--- a/src/validations/time-sheets.js
+++ b/src/validations/time-sheets.js
@@ -51,7 +51,7 @@ const validateTimeSheetBody = (req, res, next) => {
 
   if (validation.error) {
     return res.status(400).json({
-      message: `Error: ${validation.error.details[0].message}`,
+      message: validation.error.details[0].message,
       data: undefined,
       error: true,
     });


### PR DESCRIPTION
TG-108:
- Deleted "Error" on message validation because it was displaying twice.

TG-110:
- Regex updated to deny the use of numbers on Name and Last Name inputs.